### PR TITLE
Laravel config and env()

### DIFF
--- a/app/Http/Controllers/MainController.php
+++ b/app/Http/Controllers/MainController.php
@@ -18,7 +18,7 @@ class MainController extends BaseController
     }
 
     public function getAppClientId() {
-        if (env('APP_ENV') === 'local') {
+        if (app()->environment('local')) {
             return config('bigcommerce.bc_local_client_id');
         } else {
             return config('bigcommerce.bc_app_client_id');
@@ -26,7 +26,7 @@ class MainController extends BaseController
     }
 
     public function getAppSecret(Request $request) {
-        if (env('APP_ENV') === 'local') {
+        if (app()->environment('local')) {
             return config('bigcommerce.bc_local_secret');
         } else {
             return config('bigcommerce.bc_app_secret');
@@ -34,7 +34,7 @@ class MainController extends BaseController
     }
 
     public function getAccessToken(Request $request) {
-        if (env('APP_ENV') === 'local') {
+        if (app()->environment('local')) {
             return config('bigcommerce.bc_local_access_token');
         } else {
             return $request->session()->get('access_token');
@@ -42,7 +42,7 @@ class MainController extends BaseController
     }
 
     public function getStoreHash(Request $request) {
-        if (env('APP_ENV') === 'local') {
+        if (app()->environment('local')) {
             return config('bigcommerce.bc_local_store_hash');
         } else {
             return $request->session()->get('store_hash');

--- a/app/Http/Controllers/MainController.php
+++ b/app/Http/Controllers/MainController.php
@@ -14,28 +14,28 @@ class MainController extends BaseController
 
     public function __construct()
     {
-        $this->baseURL = env('APP_URL');
+        $this->baseURL = config('app.url');
     }
 
     public function getAppClientId() {
         if (env('APP_ENV') === 'local') {
-            return env('BC_LOCAL_CLIENT_ID');
+            return config('bigcommerce.bc_local_client_id');
         } else {
-            return env('BC_APP_CLIENT_ID');
+            return config('bigcommerce.bc_app_client_id');
         }
     }
 
     public function getAppSecret(Request $request) {
         if (env('APP_ENV') === 'local') {
-            return env('BC_LOCAL_SECRET');
+            return config('bigcommerce.bc_local_secret');
         } else {
-            return env('BC_APP_SECRET');
+            return config('bigcommerce.bc_app_secret');
         }
     }
 
     public function getAccessToken(Request $request) {
         if (env('APP_ENV') === 'local') {
-            return env('BC_LOCAL_ACCESS_TOKEN');
+            return config('bigcommerce.bc_local_access_token');
         } else {
             return $request->session()->get('access_token');
         }
@@ -43,7 +43,7 @@ class MainController extends BaseController
 
     public function getStoreHash(Request $request) {
         if (env('APP_ENV') === 'local') {
-            return env('BC_LOCAL_STORE_HASH');
+            return config('bigcommerce.bc_local_store_hash');
         } else {
             return $request->session()->get('store_hash');
         }

--- a/config/bigcommerce.php
+++ b/config/bigcommerce.php
@@ -1,0 +1,10 @@
+<?php
+
+return [
+    'bc_local_client_id' => env('BC_LOCAL_CLIENT_ID'),
+    'bc_app_client_id' => env('BC_APP_CLIENT_ID'),
+    'bc_local_secret' => env('BC_LOCAL_SECRET'),
+    'bc_app_secret' => env('BC_APP_SECRET'),
+    'bc_local_access_token' => env('BC_LOCAL_ACCESS_TOKEN'),
+    'bc_local_store_hash' => env('BC_LOCAL_STORE_HASH'),
+];


### PR DESCRIPTION
Thanks for the great article accompanying this repo, really useful content for Big Commerce developers. Wanted to add a small note that might save some of those who are new to Laravel a gotcha down the road if they build out from this code. Must confess I haven't fully tested this but everything should work as I mostly copied and pasted the variables.

When Laravel's route caching is enabled, env() calls outside of configuration files will cease to work. So Laravel recommends instead using the config helper in most code which in turn looks at config files where env() is called.
https://laravel.com/docs/5.8/configuration#configuration-caching