### PR TITLE
Update session settings to allow cross-site cookies

### DIFF
--- a/config/session.php
+++ b/config/session.php
@@ -166,7 +166,7 @@ return [
     |
     */
 
-    'secure' => env('SESSION_SECURE_COOKIE', false),
+    'secure' => env('SESSION_SECURE_COOKIE', true),
 
     /*
     |--------------------------------------------------------------------------
@@ -194,6 +194,6 @@ return [
     |
     */
 
-    'same_site' => null,
+    'same_site' => 'none',
 
 ];


### PR DESCRIPTION
We hit an issue when getting the App install working within the BigCommernce store environment. This was due to the update made to Chrome and Safari updating their cookie handling settings.