### PR TITLE
fix route for inventory & reports pages

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -26,6 +26,14 @@ Route::get('/list', function () {
     return Inertia::render('List');
 });
 
+Route::get('/inventory', function () {
+    return Inertia::render('Inventory');
+})->name('inventory');
+
+Route::get('/reports', function () {
+    return Inertia::render('Reports');
+})->name('reports');
+
 Route::group(['prefix' => 'auth'], function () {
     Route::get('install', [MainController::class, 'install']);
 
@@ -40,14 +48,6 @@ Route::group(['prefix' => 'auth'], function () {
         echo 'remove-user';
         return app()->version();
     });
-
-    Route::get('/inventory', function () {
-        return Inertia::render('Inventory');
-    })->name('inventory');
-
-    Route::get('/reports', function () {
-        return Inertia::render('Reports');
-    })->name('reports');
 });
 
 Route::any('/bc-api/{endpoint}', [MainController::class, 'proxyBigCommerceAPIRequest'])


### PR DESCRIPTION
Fix route for inventory & reports pages.

The routes for those pages were incorrectly grouped with the auth endpoints

Before:  `/auth/inventory`, `/auth/reports`

After: `/inventory`, `/reports` 